### PR TITLE
fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
 # PWI
 
-A repository for practicing request pull usage for PWI 2024.
+A repository for practicing pull request usage for PWI 2024.
+
+Solution to 4th exercise to 8th list:
+
+
+```sh
+grep -o -E '[^[:alpha:]]([[:alpha:]]+)[^[:alpha:]]([[:alpha:]]+)[^[:alpha:]]\1[^[:alpha:]]' 1984.txt
+```


### PR DESCRIPTION
The `README` was incorrectly referring to *pull requests* as *request pulls*.